### PR TITLE
Changing identity comparisons to equality with numbers

### DIFF
--- a/splitjson/widgets.py
+++ b/splitjson/widgets.py
@@ -54,7 +54,7 @@ class SplitJSONWidget(forms.Widget):
         if l:
             result = ''
             for el in l:
-                if isinstance(el, list) and len(l) is 1:
+                if isinstance(el, list) and len(l) == 1:
                     result += '%s' % self._prepare_as_ul(el)
                 elif isinstance(el, list):
                     result += '<ul>'
@@ -71,7 +71,7 @@ class SplitJSONWidget(forms.Widget):
         result = []
 
         def _to_parse_key(k, v):
-            if k.find(self.separator) is not -1:
+            if k.find(self.separator) != -1:
                 apx, _, nk = k.rpartition(self.separator)
                 try:
                     # parse list
@@ -127,7 +127,7 @@ class SplitJSONWidget(forms.Widget):
             if k in copy_raw_data:
                 # to transform value from list to string
                 v = v[0] if isinstance(v, list) and len(v) is 1 else v
-                if k.find(self.separator) is not -1:
+                if k.find(self.separator) != -1:
                     d = _to_parse_key(k, v)
                     # set type result
                     if not len(result):


### PR DESCRIPTION
It's an implementation detail of CPython that something like `len(v) is 1` works. It is possible to have a case where `int(1) == 1 and int(1) is 1` is False. It's never gonna happen ever, but my pedant hat was on.
